### PR TITLE
:bug: Fix `ClimateDevice` deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ You can find installation instructions for specific Home Assistant versions belo
 
 | Home Assistant version  | Heatzy component version                                  |
 | ----------------------- | --------------------------------------------------------- |
-| 0.96 and higher         | [master](#installation-for-home-assistant-096-and-higher) |
+| 0.110 and higher        | [master](#installation-for-home-assistant-0110-and-higher) |
+| 0.96 to 0.109           | [3.1.0](#installation-for-home-assistant-096-to-0109)  |
 | 0.89 to 0.95            | [2.0.1](#installation-for-home-assistant-089-to-095)      |
 | 0.88 and lower          | [1.1.1](#installation-for-home-assistant-088-and-lower)   |
 
-### Installation for Home Assistant 0.96 and higher
+### Installation for Home Assistant 0.110 and higher
 
 The following commands assume that your Home Assistant folder is located in `~/.homeassistant/custom_components`:
 
@@ -25,6 +26,23 @@ mkdir -p ~/.homeassistant/custom_components
 cd ~/.homeassistant/custom_components
 # Fetch this repo and extract it
 curl -L https://api.github.com/repos/Devotics/heatzy-home-hassistant/tarball/master | tar -xz
+# Copy heatzy folder
+cp -rl Devotics-heatzy-home-hassistant-*/heatzy .
+# Clean up
+rm -rf Devotics-heatzy-home-hassistant-*
+```
+
+### Installation for Home Assistant 0.96 to 0.109
+
+Version 4.0.0 of this component removes some deprecation notices introduced by [this pull request](https://github.com/home-assistant/core/pull/34591). You can still install a compatible version for Home Assistant versions 0.96 to 0.109 with the following instructions:
+
+```bash
+# Create custom_components folder
+mkdir -p ~/.homeassistant/custom_components
+# Move to the custom_components folder
+cd ~/.homeassistant/custom_components
+# Fetch this repo and extract it
+curl -L https://api.github.com/repos/Devotics/heatzy-home-hassistant/tarball/3.1.0 | tar -xz
 # Copy heatzy folder
 cp -rl Devotics-heatzy-home-hassistant-*/heatzy .
 # Clean up

--- a/heatzy/pilote_v1.py
+++ b/heatzy/pilote_v1.py
@@ -1,4 +1,4 @@
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (HVAC_MODE_AUTO,
                                                     PRESET_AWAY,
                                                     PRESET_COMFORT, PRESET_ECO,
@@ -21,7 +21,7 @@ HA_TO_HEATZY_STATE = {
 }
 
 
-class HeatzyPiloteV1Thermostat(ClimateDevice):
+class HeatzyPiloteV1Thermostat(ClimateEntity):
     def __init__(self, api, device):
         self._api = api
         self._device = device

--- a/heatzy/pilote_v2.py
+++ b/heatzy/pilote_v2.py
@@ -1,4 +1,4 @@
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (HVAC_MODE_AUTO,
                                                     PRESET_AWAY,
                                                     PRESET_COMFORT, PRESET_ECO,
@@ -21,7 +21,7 @@ HA_TO_HEATZY_STATE = {
 }
 
 
-class HeatzyPiloteV2Thermostat(ClimateDevice):
+class HeatzyPiloteV2Thermostat(ClimateEntity):
     def __init__(self, api, device):
         self._api = api
         self._device = device


### PR DESCRIPTION
This PR fixes `ClimateDevice` deprecation notices introduced by https://github.com/home-assistant/core/pull/34591.